### PR TITLE
puppetlabs/clj-parent: Update 7.2.3->7.3.33

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :min-lein-version "2.9.1"
-  :parent-project {:coords [puppetlabs/clj-parent "7.2.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "7.3.33"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort


### PR DESCRIPTION
Test to verify that 7.3.33 has breaking changes. See https://github.com/OpenVoxProject/jruby-utils/pull/8