### PR TITLE
ci: enable automerge for dependabot and renovate bot

### DIFF
--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: lein-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # minimal required permissions to clone repo
 
@@ -58,3 +62,20 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
+
+  automerge:
+    name: Enable auto-merge
+    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]')
+    needs:
+      - tests
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge for PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: gh pr merge --auto --merge --match-head-commit "$PR_HEAD_SHA" "$PR_URL"


### PR DESCRIPTION
- add concurency-group to cancel all workflows on a new push
- add --match-head-commit to enable only if head commit is the same which started the workflow