### PR TITLE
Prepare for JRuby 10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def i18n-version "1.0.4")
 
-(defproject org.openvoxproject/jruby-utils "5.5.1-SNAPSHOT"
+(defproject org.openvoxproject/jruby-utils "6.0.0-SNAPSHOT"
   :description "A library for working with JRuby"
   :url "https://github.com/openvoxproject/jruby-utils"
   :license {:name "Apache License, Version 2.0"

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranchPatterns": ["main", "5.x"],
   "addLabels": ["renovate", "dependencies"],
   "assigneesFromCodeOwners": true,
   "automerge": true,
@@ -10,11 +11,20 @@
   "platformAutomerge": true,
 
   "packageRules": [
-    // Lock jruby-deps to the 9.4 release series. Moving to 10.0 will
-    // be a major version change.
+    // Lock JRuby to the 10.0 release series for the main branch.
+    {
+      "groupName": "jruby updates",
+      "allowedVersions": "<10.1",
+      "matchPackageNames": [
+        "org.openvoxproject:jruby-deps"
+      ]
+    },
+
+    // Lock JRuby to the 9.4 release series for the 5.x branch.
     {
       "groupName": "jruby updates",
       "allowedVersions": "<10.0",
+      "matchBaseBranches": "5.x",
       "matchPackageNames": [
         "org.openvoxproject:jruby-deps"
       ]


### PR DESCRIPTION
### Short description

This changeset prepares the project to split off a `5.x` branch that tracks JRuby 9.4 and frees the main branch up to track JRuby 10.0.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
