### PR TITLE
Update test suites with JRuby 10 compatibility

### DIFF
--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -24,7 +24,6 @@ jobs:
         java:
           - '25'
           - '21'
-          - '17'
     steps:
       - name: Check out repository code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -15,7 +15,7 @@
                                              ScriptingContainer)
            (java.io File)
            (java.util.concurrent TimeUnit Executors ExecutorService)
-           (org.jruby CompatVersion Main Ruby RubyInstanceConfig RubyInstanceConfig$CompileMode RubyInstanceConfig$ProfilingMode)
+           (org.jruby Main Ruby RubyInstanceConfig RubyInstanceConfig$CompileMode RubyInstanceConfig$ProfilingMode)
            (org.jruby.embed LocalContextScope)
            (org.jruby.runtime.profile.builtin ProfileOutput)
            (org.jruby.util KCode)

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -16,7 +16,6 @@
   (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas JRubyInstance)
            (clojure.lang IFn)
            (java.util.concurrent TimeUnit)
-           (org.jruby CompatVersion)
            (org.jruby.util.cli OutputStrings)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -9,7 +9,7 @@
             [me.raynes.fs :as fs])
   (:import (java.io StringReader)
            (com.puppetlabs.jruby_utils.pool JRubyPool)
-           (org.jruby RubyInstanceConfig$CompileMode CompatVersion RubyInstanceConfig$ProfilingMode)
+           (org.jruby RubyInstanceConfig$CompileMode RubyInstanceConfig$ProfilingMode)
            (org.jruby.util.cli Options)
            (clojure.lang ExceptionInfo)))
 

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
@@ -125,4 +125,4 @@
         (is (re-find #"bar" out))))))
 
 (deftest jruby-version-info-test
-    (is (re-find #"jruby 9." jruby-core/jruby-version-info)))
+    (is (re-find #"^jruby" jruby-core/jruby-version-info)))


### PR DESCRIPTION
### Short description

This changeset updates the test suite to be compatible with both JRuby 9 and 10:

  - Java 17 is dropped from the test matrix as Java 21 or newer is a hard requirement for JRuby 10.
  - Imports of `org.jruby.CompatVersion` were removed as that class no longer exists in JRuby 10. These were all dead code as the `CompatVersion` class was never utilized.
  - A test asserting `jruby-core/jruby-version-info` returns data was made generic instead of version-specific.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
