### PR TITLE
Ensure GEM_PATH always contains JRuby bundled gems

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -24,6 +24,11 @@
    9k."
     :jit)
 
+(def jruby-bundled-gems
+  "The gem repository inside jruby-stdlib.jar. Contains the 'bundled' gems
+  that are part of the Ruby Standard Library."
+  "uri:classloader:/META-INF/jruby.home/lib/ruby/gems/shared")
+
 (def default-borrow-timeout
   "Default timeout when borrowing instances from the JRuby pool in
    milliseconds. Current value is 1200000ms, or 20 minutes."
@@ -92,8 +97,8 @@
   [env :- {schema/Str schema/Str}
    config :- jruby-schemas/JRubyConfig]
   (if-let [gem-path (:gem-path config)]
-    (assoc env "GEM_PATH" gem-path)
-    env))
+    (assoc env "GEM_PATH" (str gem-path ":" jruby-bundled-gems))
+    (assoc env "GEM_PATH" jruby-bundled-gems)))
 
 (def proxy-vars-allowed-list
   "A list of proxy-related variables that are allowed to be passed the environment"

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -15,7 +15,7 @@
        ;; but are not expected to be set in most environments. However, in
        ;; order to make this more test robust, these variables are always
        ;; filtered out.
-       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
+       (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
               (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env)))))))))
 
 (deftest jruby-configured-env-vars
@@ -28,6 +28,6 @@
        ;; but are not expected to be set in most environments. However, in
        ;; order to make this test more robust, these variables are always
        ;; filtered out.
-       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
+       (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
               (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env)))))
        (is (= (.get jruby-env "FOO") "for_jruby"))))))


### PR DESCRIPTION
### Short description

The Ruby standard library is split into two pieces:

  - Default gems, which are installed directly into the `$LOAD_PATH`
    alongside core Ruby code.

  - Bundled gems, which are installed into a repository that the
    `Gem` library looks at by default.

JRuby ships the latter inside `jruby-stdlib.jar`, which can be
referenced be referenced by the following Java classloader URI:

    uri:classloader:/META-INF/jruby.home/lib/ruby/gems/shared

This commit updates the logic for setting `GEM_PATH` to always append
the classloader URI to the end of any path configured by the
application. This ensures that the full JRuby standard library is
available by default, and that any updates from new JRuby versions are
automatically taken up.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
