### PR TITLE
Default jruby.compile.invokedynamic to false

### DIFF
--- a/src/clj/openvox/jruby_utils/jruby_defaults.clj
+++ b/src/clj/openvox/jruby_utils/jruby_defaults.clj
@@ -1,0 +1,37 @@
+(ns openvox.jruby-utils.jruby-defaults
+  "Requiring this namespace has one side-effect: it sets Java properties
+  read by JRuby settings in order to change default behavior, while retaining
+  the ability for users to explicitly overrride settings via JAVA_ARGS.
+
+  This namespace should be required very early in the application lifecycle,
+  before any classes are imported from org.jruby, as some properties are read
+  once during class initialization and then never consulted again.")
+
+(def defaults
+  "Map of String->String indicating defaults to set in JVM properties that
+  influence JRuby behavior."
+  {
+    ;; JRuby 9.4 defaulted to false, JRuby 10.0 changes to true. Using
+    ;; InvokeDynamic can ultimately produce faster code, but this comes at the
+    ;; cost of a slower, more volatile warm-up period. So, keep the 9.4 default
+    ;; of false as OpenVox continually creates anonymous Ruby classes that
+    ;; repeatedly trigger expensive compilation.
+    ;;
+    ;; Re-visit if improvements are made on the JRuby side to reduce cost, or
+    ;; on the OpenVox side to reduce the number of ephemeral Ruby classes that
+    ;; force the JRuby compiler to repeatedly re-compile.
+    "jruby.compile.invokedynamic" "false"
+  })
+
+(defn set-jruby-property-defaults!
+  "Loop over the defaults map and set each in Java properties, if not already
+  set by some other mechanism like a `-D` flag. Return a map of properties
+  set in this way."
+  []
+  (let [properties (System/getProperties)]
+    (into {} (filter (fn [[k v]] (nil? (.putIfAbsent properties k v))) defaults))))
+
+;; This statement causes the actual side-effect of setting defaults in the Java
+;; system properties when this namespace is loaded. The variable holds a map of
+;; properties that were modified.
+(defonce defaults-set-on-load (set-jruby-property-defaults!))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -1,5 +1,9 @@
 (ns puppetlabs.services.jruby-pool-manager.jruby-schemas
-  (:require [schema.core :as schema])
+  (:require [schema.core :as schema]
+            ;; Side-effect: sets defaults in Java properties before JRuby
+            ;; classes are loaded and static initializers make decisions
+            ;; based on properties.
+            [openvox.jruby_utils.jruby_defaults])
   (:import (clojure.lang Atom Agent IFn PersistentArrayMap PersistentHashMap)
            (com.puppetlabs.jruby_utils.jruby ScriptingContainer)
            (com.puppetlabs.jruby_utils.pool LockablePool)

--- a/test/integration/openvox/jruby_utils/jruby_defaults_integration_test.clj
+++ b/test/integration/openvox/jruby_utils/jruby_defaults_integration_test.clj
@@ -1,0 +1,36 @@
+(ns openvox.jruby-utils.jruby-defaults-integration-test
+  (:require [clojure.test :refer :all]
+            [openvox.jruby-utils.jruby-testutils :as testutils]
+            [openvox.jruby-utils.jruby-defaults :as jruby-defaults])
+  (:import (clojure.lang Reflector)))
+
+(defn get-bytecode-mode
+  "Create a JRuby interpreter inside of an isolated classloader and then return
+  the bytcode mode for its JIT compiler."
+  [classloader]
+  (let [scope-class     (.loadClass classloader "org.jruby.embed.LocalContextScope")
+        singlethread    (.get (.getField scope-class "SINGLETHREAD") nil)
+        container-class (.loadClass classloader "com.puppetlabs.jruby_utils.jruby.InternalScriptingContainer")
+        container       (Reflector/invokeConstructor container-class (into-array Object [singlethread]))
+        runtime         (.getRuntime (.getProvider container))
+        visitor-class   (.loadClass classloader "org.jruby.ir.targets.JVMVisitor")
+        visitor         (Reflector/invokeStaticMethod visitor-class "newForJIT" (into-array Object [runtime]))]
+    (str (.getBytecodeMode visitor))))
+
+(use-fixtures :each
+  (apply testutils/with-restored-system-properties
+    (keys jruby-defaults/defaults))
+  ;; Populates *loader* variable.
+  testutils/with-isolated-classloader)
+
+(deftest default-compile-invokedynamic-is-mixed-test
+  (testing "with no property override, JRuby's JIT compiler operates in MIXED mode."
+    (System/clearProperty "jruby.compile.invokedynamic")
+    (jruby-defaults/set-jruby-property-defaults!)
+    (is (= "MIXED" (get-bytecode-mode testutils/*loader*)))))
+
+(deftest override-compile-invokedynamic-is-honored-test
+  (testing "an explicit -Djruby.compile.invokedynamic=true, JRuby's JIT compiler operates in INDY mode."
+    (System/setProperty "jruby.compile.invokedynamic" "true")
+    (jruby-defaults/set-jruby-property-defaults!)
+    (is (= "INDY" (get-bytecode-mode testutils/*loader*)))))

--- a/test/unit/openvox/jruby_utils/jruby_defaults_test.clj
+++ b/test/unit/openvox/jruby_utils/jruby_defaults_test.clj
@@ -1,0 +1,20 @@
+(ns openvox.jruby-utils.jruby-defaults-test
+  (:require [clojure.test :refer :all]
+            [openvox.jruby-utils.jruby-testutils :as testutils]
+            [openvox.jruby-utils.jruby-defaults :as jruby-defaults]))
+
+(use-fixtures :each (apply testutils/with-restored-system-properties
+                      (keys jruby-defaults/defaults)))
+
+(deftest defaults-respect-explicit-settings
+  (testing "Does not override jruby.compile.invokedynamic when explicitly set"
+    (System/setProperty "jruby.compile.invokedynamic" "true")
+    (is (= {} (jruby-defaults/set-jruby-property-defaults!)))
+    (is (= "true" (System/getProperty "jruby.compile.invokedynamic")))))
+
+(deftest defaults-set-for-null-settings
+  (testing "Sets jruby.compile.invokedynamic to false if not already set."
+    (System/clearProperty "jruby.compile.invokedynamic")
+    (is (= {"jruby.compile.invokedynamic" "false"}
+           (jruby-defaults/set-jruby-property-defaults!)))
+    (is (= "false" (System/getProperty "jruby.compile.invokedynamic")))))

--- a/test/unit/openvox/jruby_utils/jruby_testutils.clj
+++ b/test/unit/openvox/jruby_utils/jruby_testutils.clj
@@ -1,0 +1,46 @@
+(ns openvox.jruby-utils.jruby-testutils
+  "Utility functions for JRuby tests."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import (java.net URLClassLoader URL)))
+
+(defn with-restored-system-properties
+  "Creates a test fixture that looks up named Java properties, caches their
+  values, runs the test case, then restores any cached values."
+  [& properties]
+  (fn [f]
+    (let [saved-properties (into {} (map #(do [% (System/getProperty %)])) properties)]
+      (try
+        (f)
+        (finally
+          (doseq [[k v] saved-properties]
+            (if v
+              (System/setProperty k v)
+              (System/clearProperty k))))))))
+
+
+(def ^:dynamic *loader* nil)
+
+(defn gen-isolated-loader
+  "Create an isolated class loader, populated with a copy of the JVM
+  classpath."
+  ^URLClassLoader []
+  (->> (str/split (System/getProperty "java.class.path")
+                   (re-pattern (System/getProperty "path.separator")))
+       (map #(-> (io/file %) .toURI .toURL))
+       (into-array URL)
+       ;; The last argument, nil parent, prevents delegation to the system
+       ;; classloader, ensuring true isolation
+       (#(URLClassLoader. % nil))))
+
+(defn with-isolated-classloader
+  "Creates a temporary Java classloader, assigns it to *loader* and then
+  runs the test case with that variable in-context. This enables testing
+  class variables that are initialized at load-time with different
+  system property combinations. Java reflection must be used to invoke
+  constructors and other static methods of classes loaded into the temporary
+  classloader."
+  [f]
+  (with-open [loader (gen-isolated-loader)]
+    (binding [*loader* loader]
+      (f))))


### PR DESCRIPTION
### Short description

The `jruby.compile.invokedynamic` property controls the type of JVM bytecode the JRuby compiler generates for common Ruby operations such as method calls and variable access. When set to `true`, the compiler emits `INVOKEDYNAMIC` instructions that are individualized for each Ruby operation. When set to `false`, a more generic `INVOKEVIRTUAL` is used that calls back into the JRuby runtime. The overall result is that `INVOKEDYNAMIC` is more expensive to set up, but the JVM has more ability to optimize the individual Ruby operations --- eventually producing faster JIT-compiled native code. The generic `INVOKEVIRTUAL` operation is cheaper to set up, but is also an optimization fence for the JIT compiler.

JRuby switched the default for this setting from `false` to `true` with the 10.0 release. This is a good performance trade-off for Ruby applications that have an overall static code base. Performance during the warm-up period is worse, but a fully JIT-compiled app performs better during the main phase of its lifecycle.

OpenVox as it is today does not fit the assumptions behind the new default of `true` for `jruby.compile.invokedynamic`. The application constantly creates anonymous Ruby classes to contain environment content such as Types and Providers and Custom Functions, and variable scopes for Nodes, Classes, and Defined Types active during catalog compilation. Churn in environment content can be reduced by `environment_timeout=unlimited`, but the variable scopes never survive the catalog compilation they are created for.

All of this means that `jruby.compile.invokedynamic=true` invests more up-front cost to compile Ruby classes, many of which won't live long enough to pay the investment back via JIT optimization.

This commit adds a new `openvox.jruby-utils.jruby-defaults` namespace that sets `jruby.compile.invokedynamic` to `false` when loaded, if the property has not been overridden via `JAVA_ARGS`. This namespace must be required early in the application lifecycle in order to have the desired effect --- currently accomplished by loading from the `puppetlabs.services.jruby-pool-manager.jruby-schemas` namespace.

The `invokedynamic` option may be viable in the future if the following are in place:

  - Improvements to the OpenVox code base to reduce unnecessary churn in anonymous classes.

  - Better identification of anonymous classes allowing JRuby to avoid compilation for expected high-churn areas via the `jruby.jit.exclude` property, or similar mechanisms.

  - Better access to `environment_timeout=unlimited` or other mechanisms that promote re-use of environment content in order to maximize the benefit of JIT-compiled code.

Fixes OpenvoxProject/openvox-server#600

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [x] added or modified regression test(s)
- [x] added or modified unit test(s)
