### PR TITLE
Refactor logger configuration, fix hardcoded DEBUG log level

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -69,8 +69,7 @@
                    :jvm-opts ~(let [version (System/getProperty "java.specification.version")
                                     [major minor _] (clojure.string/split version #"\.")]
                                 (concat
-                                  ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
-                                   "-XX:+UseG1GC"
+                                  ["-XX:+UseG1GC"
                                    "-Xms1G"
                                    "-Xmx2G"]
                                   (if (>= 17 (java.lang.Integer/parseInt major))

--- a/src/clj/openvox/jruby_utils/jruby_defaults.clj
+++ b/src/clj/openvox/jruby_utils/jruby_defaults.clj
@@ -21,6 +21,22 @@
     ;; on the OpenVox side to reduce the number of ephemeral Ruby classes that
     ;; force the JRuby compiler to repeatedly re-compile.
     "jruby.compile.invokedynamic" "false"
+
+    ;; Set the default JRuby logger implementation to something that is tied
+    ;; into TrapperKeeper application configuration and controllable via
+    ;; logback.xml. This system property must be set before the
+    ;; org.jruby.util.log.LoggerFactory class is loaded as a static field
+    ;; initializer binds to the setting value for the rest of the process
+    ;; lifetime.
+    ;;
+    ;; This class was created back in the JRuby 1.7 days when there was no
+    ;; SLF4J implementation provided by upstream. JRuby 9 added an official
+    ;; SLF4JLogger that is nearly identical to the one in jruby-utils. Switching
+    ;; would be a breaking change as the leading "jruby." namespace segment
+    ;; would disappear and that would break exsiting LogBack config files
+    ;; out in the field. With no clear benefit, this is not worth the break
+    ;; unless the two implementations diverge dramatically in functionality.
+    "jruby.logger.class" "com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
   })
 
 (defn set-jruby-property-defaults!

--- a/src/java/com/puppetlabs/jruby_utils/jruby/Slf4jLogger.java
+++ b/src/java/com/puppetlabs/jruby_utils/jruby/Slf4jLogger.java
@@ -7,6 +7,12 @@ public class Slf4jLogger implements Logger {
 
     private final org.slf4j.Logger logger;
 
+    // Set by JRuby when a debug-logging option such as
+    // -Djruby.invokedynamic.log.binding is given. SLF4J has no API for
+    // changing a logger's level, so track the request here and let it force
+    // isDebugEnabled() on regardless of the configured level.
+    private volatile boolean debugRequested = false;
+
     public Slf4jLogger(String loggerName) {
         logger = LoggerFactory.getLogger("jruby." + loggerName);
     }
@@ -78,11 +84,11 @@ public class Slf4jLogger implements Logger {
 
     @Override
     public boolean isDebugEnabled() {
-        return true;
+        return debugRequested || logger.isDebugEnabled();
     }
 
     @Override
     public void setDebugEnable(boolean b) {
-        warn("setDebugEnable not implemented", null, null);
+        debugRequested = b;
     }
 }

--- a/test/integration/openvox/jruby_utils/jruby_defaults_integration_test.clj
+++ b/test/integration/openvox/jruby_utils/jruby_defaults_integration_test.clj
@@ -21,7 +21,7 @@
   (apply testutils/with-restored-system-properties
     (keys jruby-defaults/defaults))
   ;; Populates *loader* variable.
-  testutils/with-isolated-classloader)
+  (testutils/with-isolated-classloader))
 
 (deftest default-compile-invokedynamic-is-mixed-test
   (testing "with no property override, JRuby's JIT compiler operates in MIXED mode."

--- a/test/unit/openvox/jruby_utils/jruby_testutils.clj
+++ b/test/unit/openvox/jruby_utils/jruby_testutils.clj
@@ -23,15 +23,29 @@
 
 (defn gen-isolated-loader
   "Create an isolated class loader, populated with a copy of the JVM
-  classpath."
-  ^URLClassLoader []
-  (->> (str/split (System/getProperty "java.class.path")
-                   (re-pattern (System/getProperty "path.separator")))
-       (map #(-> (io/file %) .toURI .toURL))
-       (into-array URL)
-       ;; The last argument, nil parent, prevents delegation to the system
-       ;; classloader, ensuring true isolation
-       (#(URLClassLoader. % nil))))
+  classpath.
+
+  delegated-prefixes is a, possibly empty, vector of namespaces to
+  delegate to the main classloader instead of loading in isolation.
+  This can be used to preserve some global behavior, such as logger
+  configuration."
+  ^ClassLoader [delegated-prefixes]
+  (let [urls (->> (str/split (System/getProperty "java.class.path")
+                              (re-pattern (System/getProperty "path.separator")))
+                   (map #(-> (io/file %) .toURI .toURL))
+                   (into-array URL))
+        parent (.getContextClassLoader (Thread/currentThread))]
+    ;; The last constructor argument, nil parent, prevents delegation to the
+    ;; system classloader, ensuring true isolation by default. The list of
+    ;; delegated-prefixes can be used to override this isloation for specified
+    ;; Java namespaces.
+    (proxy [URLClassLoader] [urls nil]
+      (loadClass
+        ([class-name] (.loadClass this class-name false))
+        ([class-name resolve?]
+         (if (some #(str/starts-with? class-name %) delegated-prefixes)
+           (.loadClass parent class-name)
+           (proxy-super loadClass class-name resolve?)))))))
 
 (defn with-isolated-classloader
   "Creates a temporary Java classloader, assigns it to *loader* and then
@@ -40,7 +54,8 @@
   system property combinations. Java reflection must be used to invoke
   constructors and other static methods of classes loaded into the temporary
   classloader."
-  [f]
-  (with-open [loader (gen-isolated-loader)]
-    (binding [*loader* loader]
-      (f))))
+  [& delegated-prefixes]
+  (fn [f]
+    (with-open [loader (gen-isolated-loader delegated-prefixes)]
+      (binding [*loader* loader]
+        (f)))))

--- a/test/unit/puppetlabs/jruby_utils/slj4j_logger_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/slj4j_logger_test.clj
@@ -1,13 +1,31 @@
 (ns puppetlabs.jruby-utils.slj4j-logger-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.trapperkeeper.testutils.logging :as logutils])
-  (:import (org.jruby.util.log LoggerFactory)))
+            [openvox.jruby-utils.jruby-testutils :as testutils]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils]
+            [openvox.jruby-utils.jruby-defaults :as jruby-defaults])
+  (:import (clojure.lang Reflector)))
+
+;; Populates *loader* variable. org.slf4j.* is delegated to the system
+;; classloader so log events reach the same LoggerContext with-test-logging
+;; attaches its capture appender to.
+(use-fixtures :each
+  (testutils/with-restored-system-properties "jruby.logger.class")
+  (testutils/with-isolated-classloader "org.slf4j."))
+
+(defn get-logger
+  "Loads JRuby's LoggerFactory inside of an isolated classloader and returns
+  a root Logger instance from it. The isolation is required to test the effects
+  of settings that are read by static field initializers run when the LoggerFactory
+  class is loaded for the first time."
+  [classloader logger-name]
+  (-> (.loadClass classloader "org.jruby.util.log.LoggerFactory")
+      (Reflector/invokeStaticMethod "getLogger" (into-array Object [logger-name]))))
 
 (deftest slf4j-logger-test
   (let [actual-logger-name "my-test-logger"
         exception-message "exceptionally bad news"
         expected-logger-name (str "jruby." actual-logger-name)
-        logger (LoggerFactory/getLogger actual-logger-name)
+        logger (get-logger testutils/*loader* actual-logger-name)
         actual-log-event (fn [event]
                            (assoc event :exception
                                         (when-let [exception (:exception event)]
@@ -91,3 +109,21 @@
        (is (logged?
             #(= (expected-log-event "some debug" :debug exception-message)
                 (actual-log-event %))))))))
+
+(deftest logger-class-is-explicitly-settable
+  (testing "The logger class can be explicitly set via Java properties."
+    (System/setProperty "jruby.logger.class" "org.jruby.util.log.StandardErrorLogger")
+    (jruby-defaults/set-jruby-property-defaults!)
+    (is (= "org.jruby.util.log.StandardErrorLogger"
+           (-> (get-logger testutils/*loader* "test")
+                 (.getClass)
+                 (.getName))))))
+
+(deftest logger-class-defaults-to-slf4j
+  (testing "The logger class can be explicitly set via Java properties."
+    (System/clearProperty "jruby.logger.class")
+    (jruby-defaults/set-jruby-property-defaults!)
+    (is (= "com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+           (-> (get-logger testutils/*loader* "test")
+                 (.getClass)
+                 (.getName))))))

--- a/test/unit/puppetlabs/jruby_utils/slj4j_logger_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/slj4j_logger_test.clj
@@ -127,3 +127,17 @@
            (-> (get-logger testutils/*loader* "test")
                  (.getClass)
                  (.getName))))))
+
+(deftest logger-class-defaults-to-no-debug
+  (testing "Debug behavor for the SLF4J logger defaults to off."
+    (System/clearProperty "jruby.logger.class")
+    (jruby-defaults/set-jruby-property-defaults!)
+    (is (false? (.isDebugEnabled (get-logger testutils/*loader* "test"))))))
+
+(deftest logger-class-enables-debug-when-requested
+  (testing "Debug behavor for the SLF4J logger is enabled when requested."
+    (System/clearProperty "jruby.logger.class")
+    (jruby-defaults/set-jruby-property-defaults!)
+    (let [logger (get-logger testutils/*loader* "test")]
+      (.setDebugEnable logger true)
+      (is (true? (.isDebugEnabled logger))))))


### PR DESCRIPTION
### Short description

This changeset removes the need to maintain `-Djruby.logger.class` in `JAVA_ARGS` and updates the logger implementation so that `DEBUG` is not hardcoded but settable via `logback.xml`.

Fixes OpenVoxProject/openvox-server#552

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
